### PR TITLE
Introduce a way to treat snapshot recordings as artifacts

### DIFF
--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -262,13 +262,14 @@ public func verifySnapshot<Value, Format>(
         }
         artifactsSubUrl = artifactsSubUrl.deletingLastPathComponent()
       } else {
-        failedSnapshotFileUrl = artifactsSubUrl.appendingPathComponent(snapshotFileUrl.lastPathComponent)
+        failedSnapshotFileUrl = artifactsSubUrl.appendingPathComponent("failed")
+        failedSnapshotFileUrl = failedSnapshotFileUrl.appendingPathComponent(snapshotFileUrl.lastPathComponent)
       }
 
       guard !recording, fileManager.fileExists(atPath: snapshotFileUrl.path) else {
-        let writeToUrl = treatRecordingsAsArtifacts ? failedSnapshotFileUrl : snapshotFileUrl
+        let writeToUrl = failedSnapshotFileUrl
         try fileManager.createDirectory(
-          at: treatRecordingsAsArtifacts ? artifactsSubUrl : snapshotDirectoryUrl, withIntermediateDirectories: true
+          at: writeToUrl.deletingLastPathComponent(), withIntermediateDirectories: true
         )
 
         try snapshotting.diffing.toData(diffable).write(to: writeToUrl)
@@ -314,7 +315,7 @@ public func verifySnapshot<Value, Format>(
         return nil
       }
 
-      try fileManager.createDirectory(at: artifactsSubUrl, withIntermediateDirectories: true)
+      try fileManager.createDirectory(at: failedSnapshotFileUrl.deletingLastPathComponent(), withIntermediateDirectories: true)
       try snapshotting.diffing.toData(diffable).write(to: failedSnapshotFileUrl)
 
       if !attachments.isEmpty {

--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -279,18 +279,29 @@ public func verifySnapshot<Value, Format>(
             """
       } else {
         if !fileManager.fileExists(atPath: snapshotFileUrl.path) {
-          let writeToUrl = snapshotFileUrl
+          let writeToUrl = treatRecordingsAsArtifacts
+            ? artifactsSubUrl.appendingPathComponent(snapshotFileUrl.lastPathComponent)
+            : snapshotFileUrl
+
           try fileManager.createDirectory(
             at: writeToUrl.deletingLastPathComponent(), withIntermediateDirectories: true
           )
           try snapshotting.diffing.toData(diffable).write(to: writeToUrl)
-          return """
-            No reference was found on disk. Automatically recorded snapshot: …
+          return treatRecordingsAsArtifacts
+            ? """
+              No reference was found on disk. Treating recordings as artifacts.
 
-            open "\(writeToUrl.path)"
+              open "\(writeToUrl.path)"
 
-            Re-run "\(testName)" to test against the newly-recorded snapshot.
-            """
+              Recorded snapshot: …
+              """
+            : """
+              No reference was found on disk. Automatically recorded snapshot: …
+
+              open "\(writeToUrl.path)"
+
+              Re-run "\(testName)" to test against the newly-recorded snapshot.
+              """
         }
       }
 

--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -243,7 +243,19 @@ public func verifySnapshot<Value, Format>(
         fileURLWithPath: ProcessInfo.processInfo.environment["SNAPSHOT_ARTIFACTS"] ?? NSTemporaryDirectory(), isDirectory: true
       )
       let artifactsSubUrl = artifactsUrl.appendingPathComponent(fileName)
-      let failedSnapshotFileUrl = artifactsSubUrl.appendingPathComponent(snapshotFileUrl.lastPathComponent)
+      var additionalComponents: [String] = []
+      for component in snapshotFileUrl.pathComponents.reversed() {
+        if component != fileName {
+          additionalComponents.insert(component, at: 0)
+        } else {
+          break
+        }
+      }
+
+      var failedSnapshotFileUrl = artifactsSubUrl
+      for component in additionalComponents {
+        failedSnapshotFileUrl = failedSnapshotFileUrl.appendingPathComponent(component)
+      }
 
       guard !recording, fileManager.fileExists(atPath: snapshotFileUrl.path) else {
         let writeToUrl = treatRecordingsAsArtifacts ? failedSnapshotFileUrl : snapshotFileUrl

--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -242,19 +242,27 @@ public func verifySnapshot<Value, Format>(
       let artifactsUrl = URL(
         fileURLWithPath: ProcessInfo.processInfo.environment["SNAPSHOT_ARTIFACTS"] ?? NSTemporaryDirectory(), isDirectory: true
       )
-      let artifactsSubUrl = artifactsUrl.appendingPathComponent(fileName)
-      var additionalComponents: [String] = []
-      for component in snapshotFileUrl.pathComponents.reversed() {
-        if component != fileName {
-          additionalComponents.insert(component, at: 0)
-        } else {
-          break
-        }
-      }
+      var artifactsSubUrl = artifactsUrl.appendingPathComponent(fileName)
 
-      var failedSnapshotFileUrl = artifactsSubUrl
-      for component in additionalComponents {
-        failedSnapshotFileUrl = failedSnapshotFileUrl.appendingPathComponent(component)
+      var failedSnapshotFileUrl: URL
+      if treatRecordingsAsArtifacts {
+        var additionalComponents: [String] = []
+        for component in snapshotFileUrl.pathComponents.reversed() {
+          if component != fileName {
+            additionalComponents.insert(component, at: 0)
+          } else {
+            break
+          }
+        }
+
+        failedSnapshotFileUrl = artifactsSubUrl
+        for component in additionalComponents {
+          failedSnapshotFileUrl = failedSnapshotFileUrl.appendingPathComponent(component)
+          artifactsSubUrl = artifactsSubUrl.appendingPathComponent(component)
+        }
+        artifactsSubUrl = artifactsSubUrl.deletingLastPathComponent()
+      } else {
+        failedSnapshotFileUrl = artifactsSubUrl.appendingPathComponent(snapshotFileUrl.lastPathComponent)
       }
 
       guard !recording, fileManager.fileExists(atPath: snapshotFileUrl.path) else {

--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -239,39 +239,19 @@ public func verifySnapshot<Value, Format>(
         treatRecordingsAsArtifacts = (recordingsAsArtifacts as NSString).boolValue
       }
 
-      let artifactsUrl = URL(
+      let artifactsBaseUrl = URL(
         fileURLWithPath: ProcessInfo.processInfo.environment["SNAPSHOT_ARTIFACTS"] ?? NSTemporaryDirectory(), isDirectory: true
       )
-      var artifactsSubUrl = artifactsUrl.appendingPathComponent(fileName)
+      let artifactsSubUrl = artifactsBaseUrl.appendingPathComponent(fileName)
 
-      var failedSnapshotFileUrl: URL
-      if treatRecordingsAsArtifacts {
-        var additionalComponents: [String] = []
-        for component in snapshotFileUrl.pathComponents.reversed() {
-          if component != fileName {
-            additionalComponents.insert(component, at: 0)
-          } else {
-            break
-          }
-        }
+      if recording {
+        let writeToUrl = treatRecordingsAsArtifacts
+          ? artifactsSubUrl.appendingPathComponent(snapshotFileUrl.lastPathComponent)
+          : snapshotFileUrl
 
-        failedSnapshotFileUrl = artifactsSubUrl
-        for component in additionalComponents {
-          failedSnapshotFileUrl = failedSnapshotFileUrl.appendingPathComponent(component)
-          artifactsSubUrl = artifactsSubUrl.appendingPathComponent(component)
-        }
-        artifactsSubUrl = artifactsSubUrl.deletingLastPathComponent()
-      } else {
-        failedSnapshotFileUrl = artifactsSubUrl.appendingPathComponent("failed")
-        failedSnapshotFileUrl = failedSnapshotFileUrl.appendingPathComponent(snapshotFileUrl.lastPathComponent)
-      }
-
-      guard !recording, fileManager.fileExists(atPath: snapshotFileUrl.path) else {
-        let writeToUrl = failedSnapshotFileUrl
         try fileManager.createDirectory(
           at: writeToUrl.deletingLastPathComponent(), withIntermediateDirectories: true
         )
-
         try snapshotting.diffing.toData(diffable).write(to: writeToUrl)
         #if !os(Linux) && !os(Windows)
         if ProcessInfo.processInfo.environment.keys.contains("__XCODE_BUILT_PRODUCTS_DIR_PATHS") {
@@ -282,21 +262,36 @@ public func verifySnapshot<Value, Format>(
         }
         #endif
 
-        return recording
+        return treatRecordingsAsArtifacts
           ? """
-            Record mode is on. Turn record mode off and re-run "\(testName)" to test against the newly-recorded snapshot.
+            Record mode is on. Treating recordings as artifacts.
 
             open "\(writeToUrl.path)"
 
             Recorded snapshot: …
             """
           : """
+            Record mode is on. Turn record mode off and re-run "\(testName)" to test against the newly-recorded snapshot.
+
+            open "\(writeToUrl.path)"
+
+            Recorded snapshot: …
+            """
+      } else {
+        if !fileManager.fileExists(atPath: snapshotFileUrl.path) {
+          let writeToUrl = snapshotFileUrl
+          try fileManager.createDirectory(
+            at: writeToUrl.deletingLastPathComponent(), withIntermediateDirectories: true
+          )
+          try snapshotting.diffing.toData(diffable).write(to: writeToUrl)
+          return """
             No reference was found on disk. Automatically recorded snapshot: …
 
             open "\(writeToUrl.path)"
 
             Re-run "\(testName)" to test against the newly-recorded snapshot.
             """
+        }
       }
 
       let data = try Data(contentsOf: snapshotFileUrl)
@@ -315,8 +310,13 @@ public func verifySnapshot<Value, Format>(
         return nil
       }
 
-      try fileManager.createDirectory(at: failedSnapshotFileUrl.deletingLastPathComponent(), withIntermediateDirectories: true)
-      try snapshotting.diffing.toData(diffable).write(to: failedSnapshotFileUrl)
+      let writeToUrl = artifactsSubUrl
+        .appendingPathComponent("failed")
+        .appendingPathComponent(snapshotFileUrl.lastPathComponent)
+      try fileManager.createDirectory(
+        at: writeToUrl.deletingLastPathComponent(), withIntermediateDirectories: true
+      )
+      try snapshotting.diffing.toData(diffable).write(to: writeToUrl)
 
       if !attachments.isEmpty {
         #if !os(Linux) && !os(Windows)
@@ -331,12 +331,12 @@ public func verifySnapshot<Value, Format>(
       }
 
       let diffMessage = diffTool
-        .map { "\($0) \"\(snapshotFileUrl.path)\" \"\(failedSnapshotFileUrl.path)\"" }
+        .map { "\($0) \"\(snapshotFileUrl.path)\" \"\(writeToUrl.path)\"" }
         ?? """
         @\(minus)
         "\(snapshotFileUrl.path)"
         @\(plus)
-        "\(failedSnapshotFileUrl.path)"
+        "\(writeToUrl.path)"
 
         To configure output for a custom diff tool, like Kaleidoscope:
 

--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -202,8 +202,6 @@ public func verifySnapshot<Value, Format>(
       let snapshotFileUrl = snapshotDirectoryUrl
         .appendingPathComponent("\(testName).\(identifier)")
         .appendingPathExtension(snapshotting.pathExtension ?? "")
-      let fileManager = FileManager.default
-      try fileManager.createDirectory(at: snapshotDirectoryUrl, withIntermediateDirectories: true)
 
       let tookSnapshot = XCTestExpectation(description: "Took snapshot")
       var optionalDiffable: Format?
@@ -233,13 +231,31 @@ public func verifySnapshot<Value, Format>(
       guard var diffable = optionalDiffable else {
         return "Couldn't snapshot value"
       }
-      
+
+      let fileManager = FileManager.default
+
+      var treatRecordingsAsArtifacts = false
+      if let recordingsAsArtifacts = ProcessInfo.processInfo.environment["TREAT_RECORDINGS_AS_ARTIFACTS"] {
+        treatRecordingsAsArtifacts = (recordingsAsArtifacts as NSString).boolValue
+      }
+
+      let artifactsUrl = URL(
+        fileURLWithPath: ProcessInfo.processInfo.environment["SNAPSHOT_ARTIFACTS"] ?? NSTemporaryDirectory(), isDirectory: true
+      )
+      let artifactsSubUrl = artifactsUrl.appendingPathComponent(fileName)
+      let failedSnapshotFileUrl = artifactsSubUrl.appendingPathComponent(snapshotFileUrl.lastPathComponent)
+
       guard !recording, fileManager.fileExists(atPath: snapshotFileUrl.path) else {
-        try snapshotting.diffing.toData(diffable).write(to: snapshotFileUrl)
+        let writeToUrl = treatRecordingsAsArtifacts ? failedSnapshotFileUrl : snapshotFileUrl
+        try fileManager.createDirectory(
+          at: treatRecordingsAsArtifacts ? artifactsSubUrl : snapshotDirectoryUrl, withIntermediateDirectories: true
+        )
+
+        try snapshotting.diffing.toData(diffable).write(to: writeToUrl)
         #if !os(Linux) && !os(Windows)
         if ProcessInfo.processInfo.environment.keys.contains("__XCODE_BUILT_PRODUCTS_DIR_PATHS") {
           XCTContext.runActivity(named: "Attached Recorded Snapshot") { activity in
-            let attachment = XCTAttachment(contentsOfFile: snapshotFileUrl)
+            let attachment = XCTAttachment(contentsOfFile: writeToUrl)
             activity.add(attachment)
           }
         }
@@ -249,14 +265,14 @@ public func verifySnapshot<Value, Format>(
           ? """
             Record mode is on. Turn record mode off and re-run "\(testName)" to test against the newly-recorded snapshot.
 
-            open "\(snapshotFileUrl.path)"
+            open "\(writeToUrl.path)"
 
             Recorded snapshot: …
             """
           : """
             No reference was found on disk. Automatically recorded snapshot: …
 
-            open "\(snapshotFileUrl.path)"
+            open "\(writeToUrl.path)"
 
             Re-run "\(testName)" to test against the newly-recorded snapshot.
             """
@@ -278,12 +294,7 @@ public func verifySnapshot<Value, Format>(
         return nil
       }
 
-      let artifactsUrl = URL(
-        fileURLWithPath: ProcessInfo.processInfo.environment["SNAPSHOT_ARTIFACTS"] ?? NSTemporaryDirectory(), isDirectory: true
-      )
-      let artifactsSubUrl = artifactsUrl.appendingPathComponent(fileName)
       try fileManager.createDirectory(at: artifactsSubUrl, withIntermediateDirectories: true)
-      let failedSnapshotFileUrl = artifactsSubUrl.appendingPathComponent(snapshotFileUrl.lastPathComponent)
       try snapshotting.diffing.toData(diffable).write(to: failedSnapshotFileUrl)
 
       if !attachments.isEmpty {


### PR DESCRIPTION
Our use case would prefer having the option of treating snapshot recordings (record mode as well as non-existent files) as artifacts, placing them in the same directory as failures. This PR introduces a new env option, TREAT_RECORDINGS_AS_ARTIFACTS to accomplish this goal. When set to true, new snapshot recordings will be placed in the same directory as SNAPSHOT_ARTIFACTS. When set to false, the intention is to have the same behavior as before.

https://github.com/pointfreeco/swift-snapshot-testing/pull/495