### PR TITLE
Use absolute string for no reference snapshots failures

### DIFF
--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -291,7 +291,7 @@ public func verifySnapshot<Value, Format>(
             ? """
               No reference was found on disk. Treating recordings as artifacts.
 
-              open "\(writeToUrl.path)"
+              open "\(writeToUrl.absoluteString)"
 
               Recorded snapshot: …
               """


### PR DESCRIPTION
Use absolute string for clickable links in the inline test failure. This needs to be added manually since our use case does splitting of recording and non-recording modes. 