### PR TITLE
Fix another availability warning

### DIFF
--- a/Sources/SnapshotTesting/Common/View.swift
+++ b/Sources/SnapshotTesting/Common/View.swift
@@ -1048,10 +1048,8 @@ private func getKeyWindow() -> UIWindow? {
       let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
       let scene = scenes.first { $0.screen == UIScreen.main } ?? scenes.first
       window = scene?.keyWindow
-  } else if #available(iOS 13.0, *) {
-      window = UIApplication.sharedIfAvailable?.windows.first { $0.isKeyWindow }
   } else {
-      window = UIApplication.sharedIfAvailable?.keyWindow
+      window = UIApplication.sharedIfAvailable?.windows.first { $0.isKeyWindow }
   }
   return window
 }


### PR DESCRIPTION
```
Sources/SnapshotTesting/Common/View.swift:1051:13: error: unnecessary check for 'iOS'; enclosing scope ensures guard will always be true
  } else if #available(iOS 13.0, *) {
            ^
Sources/SnapshotTesting/Common/View.swift:1047:3: note: enclosing scope here
  if #available(iOS 15.0, *) {
  ^
```
